### PR TITLE
Fixed old Cypress tests/Modified users component to support Angular testing

### DIFF
--- a/application/cypress.config.ts
+++ b/application/cypress.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from "cypress";
 
 export default defineConfig({
+
+  viewportWidth: 1600,
+  viewportHeight: 1050,
+
   component: {
     devServer: {
       framework: "angular",

--- a/application/cypress/e2e/spec.cy.ts
+++ b/application/cypress/e2e/spec.cy.ts
@@ -14,7 +14,7 @@ describe('Sign Up Page', () => {
     cy.request({
       method: 'POST', 
       url: 'http://localhost:8080/users/create', 
-      body: JSON.stringify({ name: 'd3', username: 'd3', email: 'd3', password: 'd3', password2: 'd3' }),
+      body: JSON.stringify({ name: 'dylan', username: 'dylan10', email: 'fake@fakemail.com', password: 'dylanmail1' }),
       headers: {'Content-Type': 'application/json'},
       failOnStatusCode: false
     })
@@ -28,22 +28,19 @@ describe('Sign Up Page', () => {
     cy.visit('http://localhost:4200/signup')
     cy.url().should('include', 'http://localhost:4200/signup')
 
-    cy.get('input[type=name]').type('d3')
-    cy.get('input[type=name]').should('have.value', 'd3')
+    cy.get('#name').type('dylan')
+    cy.get('#name').should('have.value', 'dylan')
 
-    cy.get('input[type=username]').type('d3')
-    cy.get('input[type=username]').should('have.value', 'd3')
+    cy.get('#username').type('dylan10')
+    cy.get('#username').should('have.value', 'dylan10')
 
-    cy.get('input[type=email]').type('d3')
-    cy.get('input[type=email]').should('have.value', 'd3')
+    cy.get('#email').type('fake@fakemail.com')
+    cy.get('#email').should('have.value', 'fake@fakemail.com')
 
-    cy.get('input[type=password]').type('d3')
-    cy.get('input[type=password]').should('have.value', 'd3')
+    cy.get('#password').type('dylanmail1')
+    cy.get('#password').should('have.value', 'dylanmail1')
 
-    cy.get('input[type=password2]').type('d3')
-    cy.get('input[type=password2]').should('have.value', 'd3')
-
-    cy.get('button').click()
+    cy.get('#submit').click()
   })
 
   //NOTE: The input data will have to change for this everytime the test is ran
@@ -56,7 +53,7 @@ describe('Sign Up Page', () => {
     cy.request({
       method: 'POST', 
       url: 'http://localhost:8080/users/create', 
-      body: JSON.stringify({ name: 'd55', username: 'd55', email: 'd55', password: 'd55', password2: 'd55' }),
+      body: JSON.stringify({ name: 'd55', username: 'd55', email: 'd55', password: 'd55' }),
       headers: {'Content-Type': 'application/json'}
     })
     .then( (response) => {
@@ -81,9 +78,6 @@ describe('Sign Up Page', () => {
     cy.get('input[type=password]').type('d55')
     cy.get('input[type=password]').should('have.value', 'd55')
 
-    cy.get('input[type=password2]').type('d55')
-    cy.get('input[type=password2]').should('have.value', 'd55')
-
     cy.get('button').click()
   })
   */
@@ -97,7 +91,7 @@ describe('Login Page', () => {
     cy.request({
       method: 'POST', 
       url: 'http://localhost:8080/users/login', 
-      body: JSON.stringify({ username: 'fakemail@fake.com', password: 'password' }),
+      body: JSON.stringify({ username: 'dylan', password: 'password' }),
       headers: {'Content-Type': 'application/json'},
       failOnStatusCode: false
     })
@@ -111,13 +105,13 @@ describe('Login Page', () => {
     cy.visit('http://localhost:4200/login')
     cy.url().should('include', 'http://localhost:4200/login')
 
-    cy.get('input[type=username]').type('fakemail@fake.com')
-    cy.get('input[type=username]').should('have.value', 'fakemail@fake.com')
+    cy.get('#username').type('dylan')
+    cy.get('#username').should('have.value', 'dylan')
 
-    cy.get('input[type=password]').type('password')
-    cy.get('input[type=password]').should('have.value', 'password')
+    cy.get('#password').type('password')
+    cy.get('#password').should('have.value', 'password')
     
-    cy.get('button').click()    
+    cy.get('#submit').click()    
   })
 
   //TODO - Add testing functionality that does a POST request to http://localhost:8080/users/get
@@ -147,13 +141,13 @@ describe('Login Page', () => {
     cy.visit('http://localhost:4200/login')
     cy.url().should('include', 'http://localhost:4200/login')
 
-    cy.get('input[type=username]').type('d2')
-    cy.get('input[type=username]').should('have.value', 'd2')
+    cy.get('#username').type('dylan10')
+    cy.get('#username').should('have.value', 'dylan10')
 
-    cy.get('input[type=password]').type('d2')
-    cy.get('input[type=password]').should('have.value', 'd2')
-
-    cy.get('button').click()
+    cy.get('#password').type('dylandylan')
+    cy.get('#password').should('have.value', 'dylandylan')
+    
+    cy.get('#submit').click()    
   })
 })
 

--- a/application/src/app/admin-add/admin-add.component.html
+++ b/application/src/app/admin-add/admin-add.component.html
@@ -12,7 +12,7 @@
 </div>
 
 <div class="addSpell">
-  <section class = "spellSect">
+  <section class="spellSect">
     <h1>Add a Spell</h1>
     <form method="post" #g="ngForm" (ngSubmit)="submitSpell(g)" novalidate>
       <input name="name" type="text" placeholder="Spell Name" required="required" ngModel>

--- a/application/src/app/login/login.component.html
+++ b/application/src/app/login/login.component.html
@@ -7,7 +7,8 @@
         (ngSubmit)="onSubmit()"
   >
     <!-- The user inputs username here -->
-    <input type="text" 
+    <input type="text"
+           id="username"
            placeholder="Username" 
            formControlName="username"
            required   
@@ -27,7 +28,8 @@
     </div>
 
     <!-- The user inputs password here -->
-    <input type="password" 
+    <input type="password"
+           id="password"
            placeholder="Password" 
            formControlName="password"
            required     
@@ -43,7 +45,7 @@
       </div>
     </div>
 
-    <button class="submit" type="submit" [disabled]="!form.valid">Submit</button>
+    <button class="submit" type="submit" id="submit" [disabled]="!form.valid">Submit</button>
   </form>
 </div>
 <!-- Original Form

--- a/application/src/app/signup/signup.component.html
+++ b/application/src/app/signup/signup.component.html
@@ -28,7 +28,8 @@
     </div>
 
     <!-- The user inputs username here -->
-    <input type="text" 
+    <input type="text"
+           id="username"
            placeholder="Username" 
            formControlName="username"
            required   
@@ -48,7 +49,8 @@
     </div>
 
     <!-- The user inputs email here -->
-    <input type="email" 
+    <input type="email"
+           id="email"
            placeholder="Email" 
            formControlName="email"
            required      
@@ -65,7 +67,8 @@
     </div>
 
     <!-- The user inputs password here -->
-    <input type="password" 
+    <input type="password"
+           id="password"
            placeholder="Enter New Password" 
            formControlName="password"
            required     
@@ -98,8 +101,8 @@
     </div>
     -->
 
-    <button class="submit" type="reset" (click)="reset()">Reset Values</button>
-    <button class="submit" type="submit" [disabled]="!form.valid">Submit</button>
+    <button class="submit" type="reset" id="reset" (click)="reset()">Reset Values</button>
+    <button class="submit" type="submit" id="submit" [disabled]="!form.valid">Submit</button>
   </form>
 </div>
 

--- a/application/src/app/users/users-edit/name/name.component.html
+++ b/application/src/app/users/users-edit/name/name.component.html
@@ -14,13 +14,13 @@
 
     <!-- The user input for name is checked here -->
     <div *ngIf="form.controls['name'].invalid && (form.controls['name'].dirty || form.controls['name'].touched)" class="alert alert-danger">
-      <div class ="fieldMsg" *ngIf="form.controls['name'].errors?.['required']">
+      <div class="fieldMsg" *ngIf="form.controls['name'].errors?.['required']">
         Name is required.
       </div>
-      <div class ="fieldMsg" *ngIf="form.controls['name'].errors?.['minlength']">
+      <div class="fieldMsg" *ngIf="form.controls['name'].errors?.['minlength']">
         Name must be at least 4 characters long.
       </div>
-      <div class ="fieldMsg" *ngIf="form.controls['name'].errors?.['pattern']">
+      <div class="fieldMsg" *ngIf="form.controls['name'].errors?.['pattern']">
         Name cannot contain special characters or numbers.
       </div>
     </div>

--- a/application/src/app/users/users.component.html
+++ b/application/src/app/users/users.component.html
@@ -9,13 +9,13 @@
   <form [formGroup]="form" (ngSubmit)="submit()">
     <div class="form-group">
       <select formControlName="website" class="form-control" id="userData" (click)="submit()">
-        <option formControlName="directions" hidden selected>{{this.form.value.directions}}</option>
+        <option id="directions" hidden selected>{{this.Directions}}</option>
         <option value="Update Name">Update Name</option>
         <option value="Update Email">Update Email</option>
         <option value="Update Password">Update Password</option>
       </select>
       <div *ngIf="f.website.touched && f.website.invalid" class="alert alert-danger">
-        <div class ="fieldMsg" *ngIf="f.website.errors?.['required']">Field is required.</div>
+        <div class="fieldMsg" *ngIf="f.website.errors?.['required']">Field is required.</div>
       </div>
     </div>
   </form>

--- a/application/src/app/users/users.component.spec.ts
+++ b/application/src/app/users/users.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UsersComponent } from './users.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { HttpClientModule } from '@angular/common/http';
-import { NgForm } from '@angular/forms';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 
 describe('UsersComponent', () => {
@@ -27,6 +26,13 @@ describe('UsersComponent', () => {
     fixture.detectChanges();
   });
 
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UsersComponent);
+    component = fixture.componentInstance;
+    component.ngOnInit();
+    fixture.detectChanges();
+  });
+
   it('The /profile page renders', () => {
     expect(component).toBeTruthy();
   });
@@ -44,6 +50,27 @@ describe('UsersComponent', () => {
     it('View All Characters Button Works', async () => {
     component.getCharacters();
     expect(component.viewCharactersSubmitted).toBeTruthy();
+    });
+  });
+
+  //Describe is the function name being tested
+  describe('submit', () => {
+    it('Update Name Option Works', async () => {
+      component.form.value.website = "Update Name";
+      component.submit();
+      expect(component.editNameSubmitted).toBeTruthy();
+    });
+
+    it('Update Email Option Works', async () => {
+      component.form.value.website = "Update Email";
+      component.submit();
+      expect(component.editEmailSubmitted).toBeTruthy();
+    });
+
+    it('Update Password Option Works', async () => {
+      component.form.value.website = "Update Password";
+      component.submit();
+      expect(component.editPasswordSubmitted).toBeTruthy();
     });
   });
 

--- a/application/src/app/users/users.component.ts
+++ b/application/src/app/users/users.component.ts
@@ -13,9 +13,9 @@ export class UsersComponent {
   Name: string;
   Username: string;
   Email: string;
+  Directions: string;
 
   editNameSubmitted: Boolean;
-  editUsernameSubmitted: Boolean;
   editEmailSubmitted: Boolean;
   editPasswordSubmitted: Boolean;
 
@@ -24,18 +24,16 @@ export class UsersComponent {
 
   form = new FormGroup({  
     website: new FormControl('', Validators.required),
-    directions: new FormControl('Select a Profile Field to Update')
   });
-
 
   constructor(private http:HttpClient, private router:Router){
 
     this.Name = "";
     this.Username = "";
     this.Email = "";
+    this.Directions = "Select a Profile Field to Update";
 
-    this.editNameSubmitted = false;
-    this.editUsernameSubmitted = false; 
+    this.editNameSubmitted = false; 
     this.editEmailSubmitted = false;
     this.editPasswordSubmitted = false; 
 
@@ -67,30 +65,17 @@ export class UsersComponent {
   }
     
   submit(){  
-    // This item is user update choice dropdown
-    const select = document.getElementById("userData") as HTMLSelectElement;
-    const index = select.selectedIndex;
-    var choice = select.value;
-    // Get selected index 
-    if (index <= 0)
-      return;
-
-    if(choice === 'Update Name') {
+    if(this.form.value.website === 'Update Name') {
       this.editNameSubmitted = true;
       this.router.navigateByUrl("/profile/name");
     }
 
-    if(choice === 'Update Username') {
-      this.editUsernameSubmitted = true;
-      this.router.navigateByUrl("/profile/username");
-    }
-
-    if(choice === 'Update Email') {
+    if(this.form.value.website === 'Update Email') {
       this.editEmailSubmitted = true;
       this.router.navigateByUrl("/profile/email");
     }
 
-    if(choice === 'Update Password') {
+    if(this.form.value.website === 'Update Password') {
       this.editPasswordSubmitted = true;
       this.router.navigateByUrl("/profile/pass");
     }


### PR DESCRIPTION
- Fixed Cypress tests by adding ids to the various input fields and updating the test input to match the new validators requirements
- Modified users component to be compatible with testing
    - formControlName="directions" under an option that does not take in input is not valid for Angular testing
    - The changes I made yield the same functionality and appearance as before the changes
- Added 3 new Angular tests to check that edit profile information buttons on /profile page work correctly. See Sprint3.md changes for more detail.