### PR TITLE
Changed class information from number to string in frontend

### DIFF
--- a/application/src/app/admin-add/admin-add.component.css
+++ b/application/src/app/admin-add/admin-add.component.css
@@ -241,3 +241,111 @@ input {
   letter-spacing: 1px;
   text-align: center;
 }
+
+.submit {
+  display: inline-block;
+  *display: inline;
+  *zoom: 1;
+  padding: 4px 10px 4px;
+  margin-bottom: 0;
+  font-size: 13px;
+  font-family: Georgia, 'Times New Roman', Times, serif;
+  line-height: 18px;
+  text-align: center;
+  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
+  vertical-align: middle;
+  background-color: transparent;
+  background-repeat: repeat-x;
+  border-color: #e6e6e6 #e6e6e6 #e6e6e6;
+  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+  border: 1px solid #e6e6e6;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
+  -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
+  cursor: pointer;
+  *margin-left: .3em;
+}
+
+
+  .submit:active {
+    background-color: transparent;
+  }
+
+.submit {
+  padding: 9px 14px;
+  font-size: 15px;
+  line-height: normal;
+  -webkit-border-radius: 5px;
+  -moz-border-radius: 5px;
+  border-radius: 5px;
+}
+
+.submit:hover {
+  color: #333333;
+  text-decoration: none;
+  background-position: 0 -15px;
+  -webkit-transition: background-position 0.1s linear;
+  -moz-transition: background-position 0.1s linear;
+  -o-transition: background-position 0.1s linear;
+  transition: background-position 0.1s linear;
+}
+
+.submit:hover {
+  background-color: rgba(226, 88, 34, .36);
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 1);
+  color: rgb(255, 180, 0);
+}
+
+.submit {
+  color: white;
+  background-color: rgb(255, 180, 0);
+  background-repeat: repeat-x;
+  border: 1px solid #ff8c00;
+  text-shadow: 1px 1px 1px rgba(0,0,0,0.4);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+  .submit:active, .btn-primary.active, .btn-primary.disabled, .btn-primary[disabled] {
+    color: white;
+    background-color: rgb(255, 180, 0);
+    filter: none;
+  }
+
+.submit {
+  width: 100%;
+  display: block;
+}
+
+* {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+select {
+  font-weight: normal;
+  font-style: normal; 
+  width: 100%;
+  margin-bottom: 10px;
+  background: rgba(0,0,0,.7);
+  border: none;
+  outline: none;
+  padding: 10px;
+  font-size: 13px;
+  color: rgba(255,255,255,.7);
+  text-shadow: 1px 1px 1px rgba(0,0,0,0.6);
+  border: 1px solid rgba(0,0,0,0.3);
+  border-radius: 4px;
+  box-shadow: inset 0 -5px 45px rgba(100,100,100,0.5), 0 1px 1px rgba(255,255,255,0.2);
+  -webkit-transition: box-shadow .5s ease;
+  -moz-transition: box-shadow .5s ease;
+  -o-transition: box-shadow .5s ease;
+  transition: box-shadow .5s ease;
+}
+
+  select:focus {
+    box-shadow: inset 0 -5px 45px rgba(100,100,100,0.05), 0 1px 1px rgba(255,255,255,0.1);
+  }

--- a/application/src/app/admin-add/admin-add.component.html
+++ b/application/src/app/admin-add/admin-add.component.html
@@ -53,7 +53,17 @@
       </div>
     </div>
 
-    <!-- The user inputs the item's level here -->
+    <select id="character_dropdown_item">
+      <option disabled selected hidden>Character Level</option>
+      <option *ngFor="let level of allLevels">{{level}}</option>
+    </select>
+
+    <select id="class_dropdown_item">
+      <option disabled selected hidden>Character Class</option>
+      <option *ngFor="let iclass of allClasses">{{iclass}}</option>
+    </select>
+
+    <!-- The user inputs the item's level here 
     <input type="text"
            id="itemlevel"
            placeholder="Level" 
@@ -61,7 +71,7 @@
            required      
     />
 
-    <!-- The user input for the item's level is checked here -->
+     The user input for the item's level is checked here 
     <div *ngIf="itemForm.controls['itemlevel'].invalid && (itemForm.controls['itemlevel'].dirty || itemForm.controls['itemlevel'].touched)" class="alert alert-danger">
       <div *ngIf="itemForm.controls['itemlevel'].errors?.['required']">
         Item level is required.
@@ -71,7 +81,7 @@
       </div>
     </div>
 
-    <!-- The user inputs the item's class here -->
+     The user inputs the item's class here 
     <input type="text"
            id="itemclass"
            placeholder="Class" 
@@ -79,7 +89,7 @@
            required
     />
 
-    <!-- The user input for the item's class is checked here -->
+     The user input for the item's class is checked here 
     <div *ngIf="itemForm.controls['itemclass'].invalid && (itemForm.controls['itemclass'].dirty || itemForm.controls['itemclass'].touched)" class="alert alert-danger">
       <div *ngIf="itemForm.controls['itemclass'].errors?.['required']">
         Item class is required.
@@ -88,7 +98,7 @@
         Item class can only be 1 through 10.
       </div>
     </div>
-
+-->
     <button class="submit" type="reset" id="itemreset" (click)="itemreset()">Reset Values</button>
     <button class="submit" type="submit" id="itemsubmit" [disabled]="!itemForm.valid">Submit</button>
   </form>
@@ -151,7 +161,17 @@
         </div>
       </div>
 
-      <!-- The user inputs the spell's level here -->
+      <select id="character_dropdown_spell">
+        <option disabled selected hidden>Character Level</option>
+        <option *ngFor="let level of allLevels">{{level}}</option>
+      </select>
+  
+      <select id="class_dropdown_spell">
+        <option disabled selected hidden>Character Class</option>
+        <option *ngFor="let iclass of allClasses">{{iclass}}</option>
+      </select>
+
+      <!-- The user inputs the spell's level here 
       <input type="text"
             id="spelllevel"
             placeholder="Level" 
@@ -159,7 +179,7 @@
             required      
       />
 
-      <!-- The user input for the spell's level is checked here -->
+       The user input for the spell's level is checked here 
       <div *ngIf="spellForm.controls['spelllevel'].invalid && (spellForm.controls['spelllevel'].dirty || spellForm.controls['spelllevel'].touched)" class="alert alert-danger">
         <div *ngIf="spellForm.controls['spelllevel'].errors?.['required']">
           Spell level is required.
@@ -169,7 +189,7 @@
         </div>
       </div>
 
-      <!-- The user inputs the spell's class here -->
+       The user inputs the spell's class here
       <input type="text"
             id="spellclass"
             placeholder="Class" 
@@ -177,7 +197,7 @@
             required
       />
 
-      <!-- The user input for the spell's class is checked here -->
+       The user input for the spell's class is checked here 
       <div *ngIf="spellForm.controls['spellclass'].invalid && (spellForm.controls['spellclass'].dirty || spellForm.controls['spellclass'].touched)" class="alert alert-danger">
         <div *ngIf="spellForm.controls['spellclass'].errors?.['required']">
           Spell class is required.
@@ -186,7 +206,7 @@
           Spell class can only be 1 through 10.
         </div>
       </div>
-
+-->
       <button class="submit" type="reset" id="spellreset" (click)="spellreset()">Reset Values</button>
       <button class="submit" type="submit" id="spellsubmit" [disabled]="!spellForm.valid">Submit</button>
     </form>

--- a/application/src/app/admin-add/admin-add.component.ts
+++ b/application/src/app/admin-add/admin-add.component.ts
@@ -12,11 +12,15 @@ export class AdminAddComponent {
 
   itemForm: FormGroup = new FormGroup({});
   spellForm: FormGroup = new FormGroup({});
+  allClasses: Array<string>;
+  allLevels: Array<Number>;
 
   itemSubmitted: Boolean;
   spellSubmitted: Boolean;
 
-  constructor(private fb: FormBuilder, private http: HttpClient, private router: Router) { 
+  constructor(private fb: FormBuilder, private http: HttpClient, private router: Router) {
+    this.allClasses = ["Sorcerer", "Barbarian", "Bard", "Druid", "Shaman", "Hunter", "Necromancer", "Rogue", "Paladin", "Priest"];
+    this.allLevels = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20];
     this.itemSubmitted = false;
     this.spellSubmitted = false;
   }
@@ -30,15 +34,15 @@ export class AdminAddComponent {
     this.itemForm = this.fb.group({
       itemname: new FormControl("", [Validators.required, Validators.minLength(4), Validators.maxLength(30), Validators.pattern('[a-zA-Z ]*')]),
       itemdescription: new FormControl("", [Validators.required, Validators.minLength(4), Validators.maxLength(30), Validators.pattern('[a-zA-Z.,? ]*')]),
-      itemlevel: new FormControl("", [Validators.required, Validators.pattern('^(1?[1-9]|10|20)$')]),
-      itemclass: new FormControl("", [Validators.required, Validators.pattern('^([1-9]|10)$')]),
+      //itemlevel: new FormControl("", [Validators.required, Validators.pattern('^(1?[1-9]|10|20)$')]),
+      //itemclass: new FormControl("", [Validators.required, Validators.pattern('^([1-9]|10)$')]),
     })
 
     this.spellForm = this.fb.group({
       spellname: new FormControl("", [Validators.required, Validators.minLength(4), Validators.maxLength(30), Validators.pattern('[a-zA-Z ]*')]),
       spelldescription: new FormControl("", [Validators.required, Validators.minLength(4), Validators.maxLength(30), Validators.pattern('[a-zA-Z.,? ]*')]),
-      spelllevel: new FormControl("", [Validators.required, Validators.pattern('^(1?[1-9]|10|20)$')]),
-      spellclass: new FormControl("", [Validators.required, Validators.pattern('^([1-9]|10)$')]),
+      //spelllevel: new FormControl("", [Validators.required, Validators.pattern('^(1?[1-9]|10|20)$')]),
+      //spellclass: new FormControl("", [Validators.required, Validators.pattern('^([1-9]|10)$')]),
     })
   }
 
@@ -47,12 +51,57 @@ export class AdminAddComponent {
 
     this.itemSubmitted = true;
 
+    const selectLevel = document.getElementById("character_dropdown_item") as HTMLSelectElement;
+    let level = selectLevel.options[selectLevel.selectedIndex].value;
+    
+    const select = document.getElementById("class_dropdown_item") as HTMLSelectElement;
+    let curClass = select.options[select.selectedIndex].value;
+    let currentClass = 0;
+
+    switch (curClass) {
+      case "Sorcerer":
+        currentClass = 1;
+        break;
+      case "Barbarian":
+        currentClass = 2;
+        break;
+      case "Bard":
+        currentClass = 3;
+        break;
+      case "Druid":
+        currentClass = 4;
+        break;
+      case "Shaman":
+        currentClass = 5;
+        break;
+      case "Hunter":
+        currentClass = 6;
+        break;
+      case "Necromancer":
+        currentClass = 7;
+        break;
+      case "Rogue":
+        currentClass = 8;
+        break;
+      case "Paladin":
+        currentClass = 9;
+        break;
+      case "Priest":
+        currentClass = 10;
+        break;
+      default:
+        alert("Invalid class choice.");
+        break;
+    }
+
     let BuildItem = {
       "AdminToken": localStorage.getItem('id_token'),
       "Name": this.itemForm.controls['itemname'].value,
       "Description": this.itemForm.controls['itemdescription'].value,
-      "LevelReq": Number(this.itemForm.controls['itemlevel'].value),
-      "ClassReq": Number(this.itemForm.controls['itemclass'].value),
+      "LevelReq": Number(level),
+      "ClassReq": currentClass,
+      //"LevelReq": Number(this.itemForm.controls['itemlevel'].value),
+      //"ClassReq": Number(this.itemForm.controls['itemclass'].value),
     }
 
     const options = { headers: { 'Content-Type': 'application/json' } };
@@ -80,12 +129,57 @@ export class AdminAddComponent {
 
     this.spellSubmitted = true;
 
+    const selectLevel = document.getElementById("character_dropdown_spell") as HTMLSelectElement;
+    let level = selectLevel.options[selectLevel.selectedIndex].value;
+    
+    const select = document.getElementById("class_dropdown_spell") as HTMLSelectElement;
+    let curClass = select.options[select.selectedIndex].value;
+    let currentClass = 0;
+
+    switch (curClass) {
+      case "Sorcerer":
+        currentClass = 1;
+        break;
+      case "Barbarian":
+        currentClass = 2;
+        break;
+      case "Bard":
+        currentClass = 3;
+        break;
+      case "Druid":
+        currentClass = 4;
+        break;
+      case "Shaman":
+        currentClass = 5;
+        break;
+      case "Hunter":
+        currentClass = 6;
+        break;
+      case "Necromancer":
+        currentClass = 7;
+        break;
+      case "Rogue":
+        currentClass = 8;
+        break;
+      case "Paladin":
+        currentClass = 9;
+        break;
+      case "Priest":
+        currentClass = 10;
+        break;
+      default:
+        alert("Invalid class choice.");
+        break;
+    }
+
     let BuildSpell = {
       "AdminToken": localStorage.getItem('id_token'),
       "Name": this.spellForm.controls['spellname'].value,
       "Description": this.spellForm.controls['spelldescription'].value,
-      "LevelReq": Number(this.spellForm.controls['spelllevel'].value),
-      "ClassReq": Number(this.spellForm.controls['spellclass'].value),
+      "LevelReq": Number(level),
+      "ClassReq": currentClass,
+      //"LevelReq": Number(this.spellForm.controls['spelllevel'].value),
+      //"ClassReq": Number(this.spellForm.controls['spellclass'].value),
     }
 
     const options = { headers: { 'Content-Type': 'application/json' } };

--- a/application/src/app/admin-delete/admin-delete.component.html
+++ b/application/src/app/admin-delete/admin-delete.component.html
@@ -4,8 +4,6 @@
   </form>
   <h1></h1>
 
-  <!--<button class="submit">View Your Items</button>-->
-
   <div class="tbl-content">
     <table id="tabl" cellpadding="0" cellspacing="0" border="0">
       <thead>
@@ -13,7 +11,7 @@
           <th>Name</th>
           <th>Description</th>
           <th>Level Required</th>
-          <th>Class Required</th>
+          <th>Class</th>
           <th>Delete Item</th>
           <th>Edit Item</th>
         </tr>
@@ -39,8 +37,6 @@
   </form>
   <h1></h1>
 
-  <!--<button class="submit">View Your Items</button>-->
-
   <div class="tbl-content">
     <table id="tabl" cellpadding="0" cellspacing="0" border="0">
       <thead>
@@ -48,7 +44,7 @@
           <th>Name</th>
           <th>Description</th>
           <th>Level Required</th>
-          <th>Class Required</th>
+          <th>Class</th>
           <th>Delete Item</th>
           <th>Edit Item</th>
         </tr>

--- a/application/src/app/admin-delete/admin-delete.component.ts
+++ b/application/src/app/admin-delete/admin-delete.component.ts
@@ -60,6 +60,43 @@ export class AdminDeleteComponent {
           this.allItems.splice(0);
           var AllItems = JSON.parse(JSON.stringify(data));
           for (let i = 0; i < AllItems.length; i++) {
+
+            switch (AllItems[i].ClassReq) {
+              case 1:
+                AllItems[i].ClassReq = "Sorcerer";
+                break;
+              case 2:
+                AllItems[i].ClassReq = "Barbarian";
+                break;
+              case 3:
+                AllItems[i].ClassReq = "Bard";
+                break;
+              case 4:
+                AllItems[i].ClassReq = "Druid";
+                break;
+              case 5:
+                AllItems[i].ClassReq = "Shaman";
+                break;
+              case 6:
+                AllItems[i].ClassReq = "Hunter";
+                break;
+              case 7:
+                AllItems[i].ClassReq = "Necromancer";
+                break;
+              case 8:
+                AllItems[i].ClassReq = "Rogue";
+                break;
+              case 9:
+                AllItems[i].ClassReq = "Paladin";
+                break;
+              case 10:
+                AllItems[i].ClassReq = "Priest";
+                break;
+              default:
+                alert("Invalid class choice.");
+                break;
+            }
+
             var item = new Items(AllItems[i].Name, AllItems[i].Description, AllItems[i].LevelReq, AllItems[i].ClassReq, AllItems[i].ID);
             this.allItems.push(item);
           }
@@ -108,6 +145,43 @@ export class AdminDeleteComponent {
           this.allSpells.splice(0);
           var AllSpells = JSON.parse(JSON.stringify(data));
           for (let i = 0; i < AllSpells.length; i++) {
+
+            switch (AllSpells[i].ClassReq) {
+              case 1:
+                AllSpells[i].ClassReq = "Sorcerer";
+                break;
+              case 2:
+                AllSpells[i].ClassReq = "Barbarian";
+                break;
+              case 3:
+                AllSpells[i].ClassReq = "Bard";
+                break;
+              case 4:
+                AllSpells[i].ClassReq = "Druid";
+                break;
+              case 5:
+                AllSpells[i].ClassReq = "Shaman";
+                break;
+              case 6:
+                AllSpells[i].ClassReq = "Hunter";
+                break;
+              case 7:
+                AllSpells[i].ClassReq = "Necromancer";
+                break;
+              case 8:
+                AllSpells[i].ClassReq = "Rogue";
+                break;
+              case 9:
+                AllSpells[i].ClassReq = "Paladin";
+                break;
+              case 10:
+                AllSpells[i].ClassReq = "Priest";
+                break;
+              default:
+                alert("Invalid class choice.");
+                break;
+            }
+
             var spell = new Items(AllSpells[i].Name, AllSpells[i].Description, AllSpells[i].LevelReq, AllSpells[i].ClassReq, AllSpells[i].ID);
             this.allSpells.push(spell);
           }
@@ -221,10 +295,10 @@ class Items {
   name: string;
   description: string;
   levelReq: number;
-  classReq: number;
+  classReq: string;
   id: number;
 
-  constructor(Name: string, Description: string, LevelReq: number, ClassReq: number, ID: number) {
+  constructor(Name: string, Description: string, LevelReq: number, ClassReq: string, ID: number) {
     this.name = Name;
     this.description = Description;
     this.levelReq = LevelReq;
@@ -237,10 +311,10 @@ class Spells {
   name: string;
   description: string;
   levelReq: number;
-  classReq: number;
+  classReq: string;
   id: number;
 
-  constructor(Name: string, Description: string, LevelReq: number, ClassReq: number, ID: number) {
+  constructor(Name: string, Description: string, LevelReq: number, ClassReq: string, ID: number) {
     this.name = Name;
     this.description = Description;
     this.levelReq = LevelReq;

--- a/application/src/app/admin/admin.component.html
+++ b/application/src/app/admin/admin.component.html
@@ -1,5 +1,5 @@
 <div style="text-align:center" class="admin">
     <button class="submit" id="viewusers" (click)="viewUsers()">View Existing Users</button>
     <button class="submit" id="additemspells" (click)="addItemsAndSpells()">Create Spells or Items</button>
-    <button class="submit" id="removeitemspells" (click)="removeItemsAndSpells()">Remove Spells or Items</button>
+    <button class="submit" id="removeitemspells" (click)="removeItemsAndSpells()">Edit or Remove Spells or Items</button>
 </div>

--- a/application/src/app/characters/characters-items/characters-items.component.html
+++ b/application/src/app/characters/characters-items/characters-items.component.html
@@ -2,7 +2,7 @@
     <div class="characters">
       <select id="chars" (click)="showItems()">
         <option value="Select Character" disabled selected hidden>Select Character</option>
-        <option *ngFor="let character of allChars; let i = index" value=character.Name class="Name" id="character">{{character.Name}}</option>
+        <option *ngFor="let character of allChars" value=character.Name class="Name" id="character">{{character.Name}} - {{character.Class}}</option>
       </select>
     </div>
     <div class="tbl-content">

--- a/application/src/app/characters/characters-items/characters-items.component.ts
+++ b/application/src/app/characters/characters-items/characters-items.component.ts
@@ -47,6 +47,43 @@ export class CharactersItemsComponent {
         this.allChars.splice(0);
 
         for (var i = 0; i < chars.length; i++) {
+
+          switch (chars[i].ClassType) {
+            case 1:
+              chars[i].ClassType = "Sorcerer";
+              break;
+            case 2:
+              chars[i].ClassType = "Barbarian";
+              break;
+            case 3:
+              chars[i].ClassType = "Bard";
+              break;
+            case 4:
+              chars[i].ClassType = "Druid";
+              break;
+            case 5:
+              chars[i].ClassType = "Shaman";
+              break;
+            case 6:
+              chars[i].ClassType = "Hunter";
+              break;
+            case 7:
+              chars[i].ClassType = "Necromancer";
+              break;
+            case 8:
+              chars[i].ClassType = "Rogue";
+              break;
+            case 9:
+              chars[i].ClassType = "Paladin";
+              break;
+            case 10:
+              chars[i].ClassType = "Priest";
+              break;
+            default:
+              alert("Invalid class choice.");
+              break;
+          }
+
           var char = new character(chars[i].Name, chars[i].Level, chars[i].ClassType, chars[i].Description, chars[i].ID, chars[i].Items);
           this.allChars.push(char);
         }
@@ -94,8 +131,47 @@ export class CharactersItemsComponent {
 
         //For all items in the database
         for (var i = 0; i < items.length; i++) {
+
+          let compareClass = 0;
+
+          switch (char.Class) {
+            case "Sorcerer":
+              compareClass = 1;
+              break;
+            case "Barbarian":
+              compareClass = 2;
+              break;
+            case "Bard":
+              compareClass = 3;
+              break;
+            case "Druid":
+              compareClass = 4;
+              break;
+            case "Shaman":
+              compareClass = 5;
+              break;
+            case "Hunter":
+              compareClass = 6;
+              break;
+            case "Necromancer":
+              compareClass = 7;
+              break;
+            case "Rogue":
+              compareClass = 8;
+              break;
+            case "Paladin":
+              compareClass = 9;
+              break;
+            case "Priest":
+              compareClass = 10;
+              break;
+            default:
+              alert("Invalid class choice.");
+              break;
+          }
+
           // Filter items by class that matches current character's class
-          if (items[i].ClassReq === char.Class) {
+          if (items[i].ClassReq === compareClass) {
             // Only show item if level requirements are met along with class
             if (this.levelReqMet(items[i].LevelReq)) {
               //Create new item object
@@ -210,12 +286,12 @@ export class CharactersItemsComponent {
 class character {
   Name: string;
   Level: number;
-  Class: number;
+  Class: string;
   Description: string;
   ID: number;
   items: Map<number, Item>;
 
-  constructor(name: string, level: number, myclass: number, desc: string, id: number, allitems: Item[]) {
+  constructor(name: string, level: number, myclass: string, desc: string, id: number, allitems: Item[]) {
     this.Name = name;
     this.Level = level;
     this.Class = myclass;
@@ -235,11 +311,11 @@ class Item {
   Name: string;
   Description: string;
   Level: number;
-  Class: number;
+  Class: string;
   ID: number;
   Owned: boolean;
 
-  constructor(name: string, desc: string, level: number, myclass: number, id: number) {
+  constructor(name: string, desc: string, level: number, myclass: string, id: number) {
     this.Owned = false;
     this.Name = name;
     this.Description = desc;

--- a/application/src/app/characters/characters-spells/characters-spells.component.html
+++ b/application/src/app/characters/characters-spells/characters-spells.component.html
@@ -2,7 +2,7 @@
     <div class="characters">
       <select id="chars" (click)="showSpells()">
         <option value="Select Character" disabled selected hidden>Select Character</option>
-        <option *ngFor="let character of allChars; let i = index" value=character.Name class="Name" id="character">{{character.Name}}</option>
+        <option *ngFor="let character of allChars" value=character.Name class="Name" id="character">{{character.Name}} - {{character.Class}}</option>
       </select>
     </div>
     <div class="tbl-content">

--- a/application/src/app/characters/characters-spells/characters-spells.component.ts
+++ b/application/src/app/characters/characters-spells/characters-spells.component.ts
@@ -47,6 +47,43 @@ export class CharactersSpellsComponent {
         this.allChars.splice(0);
 
         for (var i = 0; i < chars.length; i++) {
+
+          switch (chars[i].ClassType) {
+            case 1:
+              chars[i].ClassType = "Sorcerer";
+              break;
+            case 2:
+              chars[i].ClassType = "Barbarian";
+              break;
+            case 3:
+              chars[i].ClassType = "Bard";
+              break;
+            case 4:
+              chars[i].ClassType = "Druid";
+              break;
+            case 5:
+              chars[i].ClassType = "Shaman";
+              break;
+            case 6:
+              chars[i].ClassType = "Hunter";
+              break;
+            case 7:
+              chars[i].ClassType = "Necromancer";
+              break;
+            case 8:
+              chars[i].ClassType = "Rogue";
+              break;
+            case 9:
+              chars[i].ClassType = "Paladin";
+              break;
+            case 10:
+              chars[i].ClassType = "Priest";
+              break;
+            default:
+              alert("Invalid class choice.");
+              break;
+          }
+
           var char = new character(chars[i].Name, chars[i].Level, chars[i].ClassType, chars[i].Description, chars[i].ID, chars[i].Spells);
           this.allChars.push(char);
         }
@@ -95,7 +132,46 @@ export class CharactersSpellsComponent {
         this.allSpells.splice(0);
 
         for (var i = 0; i < spells.length; i++) {
-          if (spells[i].ClassReq === char.Class) {
+
+          let compareClass = 0;
+
+          switch (char.Class) {
+            case "Sorcerer":
+              compareClass = 1;
+              break;
+            case "Barbarian":
+              compareClass = 2;
+              break;
+            case "Bard":
+              compareClass = 3;
+              break;
+            case "Druid":
+              compareClass = 4;
+              break;
+            case "Shaman":
+              compareClass = 5;
+              break;
+            case "Hunter":
+              compareClass = 6;
+              break;
+            case "Necromancer":
+              compareClass = 7;
+              break;
+            case "Rogue":
+              compareClass = 8;
+              break;
+            case "Paladin":
+              compareClass = 9;
+              break;
+            case "Priest":
+              compareClass = 10;
+              break;
+            default:
+              alert("Invalid class choice.");
+              break;
+          }
+
+          if (spells[i].ClassReq === compareClass) {
             if (this.levelReqMet(spells[i].LevelReq)) { 
               var spell = new Spell(spells[i].Name, spells[i].Description, spells[i].LevelReq, spells[i].ClassReq, spells[i].ID);
               this.allSpells.push(spell);}
@@ -203,12 +279,12 @@ export class CharactersSpellsComponent {
 class character {
   Name: string;
   Level: number;
-  Class: number;
+  Class: string;
   Description: string;
   ID: number;
   spells: Map<number, Spell>;
 
-  constructor(name: string, level: number, myclass: number, desc: string, id: number, allspells: Spell[]) {
+  constructor(name: string, level: number, myclass: string, desc: string, id: number, allspells: Spell[]) {
     this.Name = name;
     this.Level = level;
     this.Class = myclass;
@@ -228,10 +304,11 @@ class Spell {
   Name: string;
   Description: string;
   Level: number;
-  Class: number;
+  Class: string;
   ID: number;
   Owned: boolean;
-  constructor(name: string, desc: string, level: number, myclass: number, id: number) {
+
+  constructor(name: string, desc: string, level: number, myclass: string, id: number) {
     this.Owned = false;
     this.Name = name;
     this.Description = desc;

--- a/application/src/app/characters/characters.component.html
+++ b/application/src/app/characters/characters.component.html
@@ -16,13 +16,12 @@
         <tr *ngFor="let character of allChars; let i = index">
           <td id="name" contenteditable=true class="Name">{{character.Name}}</td>
           <td id="desc" contenteditable=true class="Description">{{character.Description}}</td>
-          <td id="level" contenteditable=true class="Level">{{character.Level}}</td>
-          <td id="class" contenteditable=true class="Class">{{character.Class}}</td>
+          <td id="level" contenteditable=false class="Level">{{character.Level}}</td>
+          <td id="class" contenteditable=false class="Class">{{character.Class}}</td>
           <td class="delete" (click)="deleteCharacter(character.Name, character.ID)">DELETE</td>
           <td class="edit" (click)="editCharacter(character, i)">EDIT</td>
         </tr>
       </tbody>
-
     </table>
   </div>
   <label>{{invalidName}} <br />{{invalidDesc}} <br />{{invalidLevel}} <br />{{invalidClass}} <br /></label>

--- a/application/src/app/characters/characters.component.ts
+++ b/application/src/app/characters/characters.component.ts
@@ -15,6 +15,7 @@ export class CharactersComponent {
   invalidDesc: string;
   invalidLevel: string;
   invalidClass: string;
+
   constructor(private http: HttpClient, private router: Router) {
     this.allChars = [];
     this.viewSubmitted = false;
@@ -46,7 +47,45 @@ export class CharactersComponent {
         // All user characters put in a variable for html table access
         this.allChars.splice(0);
         var chars = JSON.parse(JSON.stringify(data));
+
         for (let i = 0; i < chars.length; i++) {
+
+          switch (chars[i].ClassType) {
+            case 1:
+              chars[i].ClassType = "Sorcerer";
+              break;
+            case 2:
+              chars[i].ClassType = "Barbarian";
+              break;
+            case 3:
+              chars[i].ClassType = "Bard";
+              break;
+            case 4:
+              chars[i].ClassType = "Druid";
+              break;
+            case 5:
+              chars[i].ClassType = "Shaman";
+              break;
+            case 6:
+              chars[i].ClassType = "Hunter";
+              break;
+            case 7:
+              chars[i].ClassType = "Necromancer";
+              break;
+            case 8:
+              chars[i].ClassType = "Rogue";
+              break;
+            case 9:
+              chars[i].ClassType = "Paladin";
+              break;
+            case 10:
+              chars[i].ClassType = "Priest";
+              break;
+            default:
+              alert("Invalid class choice.");
+              break;
+          }
+
           var char = new character(chars[i].Name, chars[i].Level, chars[i].Description, chars[i].ClassType,chars[i].ID);
           this.allChars.push(char);
         }
@@ -108,19 +147,60 @@ export class CharactersComponent {
     var name = table.rows[index+1]?.cells[0]?.innerText;
     var desc = table.rows[index+1]?.cells[1]?.innerText;
     var level = new Number(table.rows[index+1]?.cells[2]?.innerText);
-    var myclass = new Number(table.rows[index + 1]?.cells[3]?.innerText);
 
-    var myChar = new character(name, level as number, desc, myclass as number, char.ID);
+    //var myclass = new Number(table.rows[index + 1]?.cells[3]?.innerText);
+    var myclass = table.rows[index + 1]?.cells[3]?.innerText;
+
+    console.log(myclass)
+    let myclassconvert = 0;
+
+    switch (myclass) {
+      case "Sorcerer":
+        myclassconvert = 1;
+        break;
+      case "Barbarian":
+        myclassconvert = 2;
+        break;
+      case "Bard":
+        myclassconvert = 3;
+        break;
+      case "Druid":
+        myclassconvert = 4;
+        break;
+      case "Shaman":
+        myclassconvert = 5;
+        break;
+      case "Hunter":
+        myclassconvert = 6;
+        break;
+      case "Necromancer":
+        myclassconvert = 7;
+        break;
+      case "Rogue":
+        myclassconvert = 8;
+        break;
+      case "Paladin":
+        myclassconvert = 9;
+        break;
+      case "Priest":
+        myclassconvert = 10;
+        break;
+      default:
+        alert("Invalid class choice.");
+        break;
+    }
+
+    //var myChar = new character(name, level as number, desc, myclass as number, char.ID);
+    var myChar = new character(name, level as number, desc, myclass, char.ID);
 
     if (this.validInfo(myChar) === true)
       return;
 
     // Create character from edited info according to backend schema
-    let Character =
-    {
+    let Character = {
       "Name": name,
 	    "Description": desc,
-	    "ClassType": myclass,
+	    "ClassType": myclassconvert,
 	    "Level": level,
 	    "OwnerToken":  localStorage.getItem('id_token'),
 	    "CharacterID": char.ID,
@@ -134,6 +214,43 @@ export class CharactersComponent {
       if (200) {
         // Character should be updated in allChars variable 
         var curChar = JSON.parse(JSON.stringify(data));
+
+        switch (curChar.ClassType) {
+          case 1:
+            curChar.ClassReq = "Sorcerer";
+            break;
+          case 2:
+            curChar.ClassReq = "Barbarian";
+            break;
+          case 3:
+            curChar.ClassReq = "Bard";
+            break;
+          case 4:
+            curChar.ClassReq = "Druid";
+            break;
+          case 5:
+            curChar.ClassReq = "Shaman";
+            break;
+          case 6:
+            curChar.ClassReq = "Hunter";
+            break;
+          case 7:
+            curChar.ClassReq = "Necromancer";
+            break;
+          case 8:
+            curChar.ClassReq = "Rogue";
+            break;
+          case 9:
+            curChar.ClassReq = "Paladin";
+            break;
+          case 10:
+            curChar.ClassReq = "Priest";
+            break;
+          default:
+            alert("Invalid class choice.");
+            break;
+        }
+
         char = new character(curChar.Name, curChar.Level, curChar.Description, curChar.ClassReq, curChar.ID);
         this.allChars[index] = char;
 
@@ -162,11 +279,11 @@ export class CharactersComponent {
   validInfo(char: character): boolean {
     this.validName(char);
     this.validDesc(char);
-    this.validLevel(char);
-    this.validClass(char);
+    //this.validLevel(char);
+    //this.validClass(char);
 
     // If no invalid data was submitted, character can be updated
-    if (this.invalidName !== "" || this.invalidDesc !== "" || this.invalidLevel !== "" || this.invalidClass !== "")
+    if (this.invalidName !== "" || this.invalidDesc !== "")// || this.invalidLevel !== "" || this.invalidClass !== "")
       return true;
 
     return false;
@@ -180,8 +297,8 @@ export class CharactersComponent {
     else if (char.Name.length > 0 && char.Name.length < 4)
       this.invalidName = "Error: Name must be at least 4 characters";
 
-    else if (char.Name.length > 50)
-      this.invalidName = "Error: Name can have up to 50 characters";
+    else if (char.Name.length > 20)
+      this.invalidName = "Error: Name can have up to 20 characters";
   }
 
   validDesc(char: character) {
@@ -192,10 +309,11 @@ export class CharactersComponent {
     else if (char.Description.length > 0 && char.Description.length < 4)
       this.invalidDesc = "Error: Description must be at least 4 characters";
 
-    else if (char.Description.length > 250)
-      this.invalidDesc = "Error: Description can have up to 250 characters";
+    else if (char.Description.length > 30)
+      this.invalidDesc = "Error: Description can have up to 30 characters";
   }
 
+  /* 
   validLevel(char: character) {
     // Level Validation
     if (char.Level <= 0)
@@ -210,19 +328,20 @@ export class CharactersComponent {
     if (char.Class <= 0)
       this.invalidClass = "Error: Class must be greater than 0";
 
-    else if (char.Class > 20)
-      this.invalidClass = "Error: Character can have a maximum class of 20";
+    else if (char.Class > 10)
+      this.invalidClass = "Error: Character can have a maximum class of 10";
   }
+  */
 }
 
 class character {
   Name: string;
   Level: number;
   Description: string;
-  Class: number;
+  Class: string;
   ID: number;
 
-  constructor(name: string, level: number, desc: string, myClass: number, id: number) {
+  constructor(name: string, level: number, desc: string, myClass: string, id: number) {
     this.Name = name;
     this.Level = level;
     this.Description = desc;

--- a/application/src/app/characters/create-characters/create-characters.component.css
+++ b/application/src/app/characters/create-characters/create-characters.component.css
@@ -139,3 +139,28 @@ label {
   text-shadow: 0 0 10px rgba(0,0,0,1);
   text-align: center;
 }
+
+select {
+  font-weight: normal;
+  font-style: normal; 
+  width: 100%;
+  margin-bottom: 10px;
+  background: rgba(0,0,0,.7);
+  border: none;
+  outline: none;
+  padding: 10px;
+  font-size: 13px;
+  color: rgba(255,255,255,.7);
+  text-shadow: 1px 1px 1px rgba(0,0,0,0.6);
+  border: 1px solid rgba(0,0,0,0.3);
+  border-radius: 4px;
+  box-shadow: inset 0 -5px 45px rgba(100,100,100,0.5), 0 1px 1px rgba(255,255,255,0.2);
+  -webkit-transition: box-shadow .5s ease;
+  -moz-transition: box-shadow .5s ease;
+  -o-transition: box-shadow .5s ease;
+  transition: box-shadow .5s ease;
+}
+
+  select:focus {
+    box-shadow: inset 0 -5px 45px rgba(100,100,100,0.05), 0 1px 1px rgba(255,255,255,0.1);
+  }

--- a/application/src/app/characters/create-characters/create-characters.component.html
+++ b/application/src/app/characters/create-characters/create-characters.component.html
@@ -1,17 +1,23 @@
-<div style="text-align:center" class="create-characters" >
-    <h1>Create A New Character</h1>
-    <form method="post" #f="ngForm" (ngSubmit)="onSubmit(f)" novalidate>
-      <input name="name" id="Name" type="text" placeholder="Character Name" required="required" ngModel />
-      <label *ngIf="validName(f.value.name)">{{invalidName}}</label>
+<div class="create-characters" >
+  <h1>Create A New Character</h1>
+  <form method="post" #f="ngForm" (ngSubmit)="onSubmit(f)" novalidate>
 
-      <input name="description" id="Desc"type="text" placeholder="Character Description" required="required" ngModel />
-      <label *ngIf="validDescription(f.value.description)">{{invalidDesc}}</label>
+    <input name="name" id="Name" type="text" placeholder="Character Name" required="required" ngModel />
+    <label *ngIf="validName(f.value.name)">{{invalidName}}</label>
 
-      <input name="level" id="Level"type="number" placeholder="Character Level" required="required" ngModel />
-      <label *ngIf="validLevel(f.value.level)">{{invalidLevel}}</label>
+    <input name="description" id="Desc" type="text" placeholder="Character Description" required="required" ngModel />
+    <label *ngIf="validDescription(f.value.description)">{{invalidDesc}}</label>
 
-      <input name="class" id="Class"type="number" placeholder="Character Class" required="required" ngModel />
-      <label *ngIf="validClass(f.value.class)">{{invalidClass}}</label>
-      <button id ="submit" class="submit">Submit</button>
-    </form>
+    <select id="character_dropdown">
+      <option disabled selected hidden>Character Level</option>
+      <option *ngFor="let level of allLevels">{{level}}</option>
+    </select>
+
+    <select id="class_dropdown">
+      <option disabled selected hidden>Character Class</option>
+      <option *ngFor="let iclass of allClasses">{{iclass}}</option>
+    </select>
+    
+    <button id ="submit" class="submit">Submit</button>
+  </form>
 </div>

--- a/application/src/app/characters/create-characters/create-characters.component.ts
+++ b/application/src/app/characters/create-characters/create-characters.component.ts
@@ -2,6 +2,7 @@ import { HttpClient, HttpHeaders, HttpRequest } from '@angular/common/http';
 import { Component } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+
 @Component({
   templateUrl: './create-characters.component.html',
   styleUrls: ['./create-characters.component.css']
@@ -9,17 +10,18 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 export class CreateCharactersComponent {
 
+  allClasses: Array<string>;
+  allLevels: Array<Number>;
   createSubmitted: Boolean;
   invalidName: string;
   invalidDesc: string;
-  invalidLevel: string;
-  invalidClass: string;
+
   constructor(private http: HttpClient, private router: Router) { 
+    this.allClasses = ["Sorcerer", "Barbarian", "Bard", "Druid", "Shaman", "Hunter", "Necromancer", "Rogue", "Paladin", "Priest"];
+    this.allLevels = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20];
     this.createSubmitted = false;
     this.invalidName ="";
     this.invalidDesc ="";
-    this.invalidLevel ="";
-    this.invalidClass ="";
   }
 
   ngOnInit() {
@@ -30,21 +32,63 @@ export class CreateCharactersComponent {
 
   onSubmit(f: NgForm) {
 
-    let Character = {
-      "Name": f.value.name,
-      "Description": f.value.description,
-      "ClassType": Number(f.value.class),
-      "Level": Number(f.value.level),
-      "OwnerToken": localStorage.getItem('id_token'),
-    };
-
     this.createSubmitted = true;
 
     // if any values are invalid do not send a post request to create character
-    if (this.validName(f.value.name) || this.validDescription(f.value.description) || this.validLevel(Number(f.value.level))
-      || this.validClass(Number(f.value.class))) 
+    if (this.validName(f.value.name) || this.validDescription(f.value.description)) 
       return;
 
+    const selectLevel = document.getElementById("character_dropdown") as HTMLSelectElement;
+    let level = selectLevel.options[selectLevel.selectedIndex].value;
+    
+    const select = document.getElementById("class_dropdown") as HTMLSelectElement;
+    let curClass = select.options[select.selectedIndex].value;
+    let currentClass = 0;
+
+    switch (curClass) {
+      case "Sorcerer":
+        currentClass = 1;
+        break;
+      case "Barbarian":
+        currentClass = 2;
+        break;
+      case "Bard":
+        currentClass = 3;
+        break;
+      case "Druid":
+        currentClass = 4;
+        break;
+      case "Shaman":
+        currentClass = 5;
+        break;
+      case "Hunter":
+        currentClass = 6;
+        break;
+      case "Necromancer":
+        currentClass = 7;
+        break;
+      case "Rogue":
+        currentClass = 8;
+        break;
+      case "Paladin":
+        currentClass = 9;
+        break;
+      case "Priest":
+        currentClass = 10;
+        break;
+      default:
+        alert("Invalid class choice.");
+        break;
+    }
+
+    let Character = {
+      "Name": f.value.name,
+      "Description": f.value.description,
+      "ClassType": currentClass,
+      "Level": Number(level),
+      "OwnerToken": localStorage.getItem('id_token'),
+    };
+  
     const options = { headers: { 'Content-Type': 'application/json' } };
     this.http.post('http://localhost:8080/characters/create', JSON.stringify(Character),options).subscribe((res: any)=> {
       if (200) {
@@ -59,7 +103,6 @@ export class CreateCharactersComponent {
           alert('Character already exists. Please try another one.');
         }
         else if (error.status === 500) {
-          
           alert('Server down.');
         }
         else if (error.status === 502) {
@@ -73,6 +116,7 @@ export class CreateCharactersComponent {
   validName(name: any): boolean {
     if (this.createSubmitted === false)
       return false;
+
     if (typeof (name) !== 'string') {
       this.invalidName = "Please enter a valid name";
       return true;
@@ -87,8 +131,8 @@ export class CreateCharactersComponent {
       return true
     }
 
-    if (name.length > 50) {
-      this.invalidName = "Name can have up to 50 characters";
+    if (name.length > 20) {
+      this.invalidName = "Name can have up to 20 characters";
       return true;
     }
 
@@ -115,54 +159,11 @@ export class CreateCharactersComponent {
       return true;
     }
 
-    if (description.length > 250) {
-      this.invalidDesc = "Description can have up to 250 characters";
+    if (description.length > 30) {
+      this.invalidDesc = "Description can have up to 30 characters";
       return true;
     }
 
-    return false;
-  }
-
-  // Sets alert to be returned if level is invalid, invalid level returns true (for ngif)
-  validLevel(level: any): boolean {
-    if (this.createSubmitted === false)
-      return false;
-
-    if (typeof (level) !== 'number') {
-      this.invalidLevel = "Please enter a valid level number";
-      return true;
-    }
-
-    if (level <= 0) {
-      this.invalidLevel = "Level must be greater than 0";
-      return true;
-    }
-
-    if (level > 20) {
-      this.invalidLevel = "Character can have a maximum level of 20";
-      return true;
-    }
-    return false;
-  }
-
-  // Sets alert to be returned if class is invalid, invalid class returns true (for ngif)
-  validClass(Class: any): boolean {
-    if (this.createSubmitted === false)
-      return false;
-
-    if (typeof (Class) !== 'number') {
-      this.invalidClass = "Please enter a valid class number";
-      return true;
-    }
-    if (Class <= 0) {
-      this.invalidClass = "Class must be greater than 0";
-      return true;
-    }
-
-    if (Class > 20) {
-      this.invalidClass = "Character can have a maximum class of 20";
-      return true;
-    }
     return false;
   }
 }

--- a/application/src/app/classes/classes.component.ts
+++ b/application/src/app/classes/classes.component.ts
@@ -22,54 +22,34 @@ export class ClassesComponent {
     //Example: The mighty sorcerer is a master of arcane magic. He can cast spells such as fireball and polymorph.
     switch (f) {
       case 1:
-        alert("The mighty sorcerer is a master of arcane magic. He can cast spells such as fireball and polymorph." + 
-        "\n\nIf you are interested in creating a character with this class:" +
-        "\n\nInput 1 for Character Class on the Create a New Character page.");
+        alert("The mighty sorcerer is a master of arcane magic. He can cast spells such as fireball and polymorph.");
         break;
       case 2:
-        alert("Insert class details here " + 
-        "\n\nIf you are interested in creating a character with this class:" +
-        "\n\nInput 2 for Character Class on the Create a New Character page.");
+        alert("Insert class details here ");
         break;
       case 3:
-        alert("Insert class details here " + 
-        "\n\nIf you are interested in creating a character with this class:" +
-        "\n\nInput 3 for Character Class on the Create a New Character page.");
+        alert("Insert class details here ");
         break;
       case 4:
-        alert("Insert class details here " + 
-        "\n\nIf you are interested in creating a character with this class:" +
-        "\n\nInput 4 for Character Class on the Create a New Character page.");
+        alert("Insert class details here ");
         break;
       case 5:
-        alert("Insert class details here " + 
-        "\n\nIf you are interested in creating a character with this class:" +
-        "\n\nInput 5 for Character Class on the Create a New Character page.");
+        alert("Insert class details here ");
         break;
       case 6:
-        alert("Insert class details here " + 
-        "\n\nIf you are interested in creating a character with this class:" +
-        "\n\nInput 6 for Character Class on the Create a New Character page.");
+        alert("Insert class details here ");
         break;
       case 7:
-        alert("Insert class details here " + 
-        "\n\nIf you are interested in creating a character with this class:" +
-        "\n\nInput 7 for Character Class on the Create a New Character page.");
+        alert("Insert class details here ");
         break;
       case 8:
-        alert("Insert class details here " + 
-        "\n\nIf you are interested in creating a character with this class:" +
-        "\n\nInput 8 for Character Class on the Create a New Character page.");
+        alert("Insert class details here ");
         break;
       case 9:
-        alert("Insert class details here " + 
-        "\n\nIf you are interested in creating a character with this class:" +
-        "\n\nInput 9 for Character Class on the Create a New Character page.");
+        alert("Insert class details here ");
         break;
       case 10:
-        alert("Insert class details here " + 
-        "\n\nIf you are interested in creating a character with this class:" +
-        "\n\nInput 10 for Character Class on the Create a New Character page.");
+        alert("Insert class details here ");
         break;
       default:
         alert("Invalid class choice.");

--- a/application/src/app/items/items.component.html
+++ b/application/src/app/items/items.component.html
@@ -2,7 +2,7 @@
   <div class="characters">
     <select id="classes" (click)="showItems()">
       <option disabled selected hidden>Select Option</option>
-      <option *ngFor="let iclass of allClasses; let i = index" class="Name" id="class_dropdown" >{{iclass}}</option>
+      <option *ngFor="let iclass of allClasses" class="Name" id="class_dropdown" >{{iclass}}</option>
     </select>
   </div>
   <div class="tbl-content">

--- a/application/src/app/spells/spells.component.html
+++ b/application/src/app/spells/spells.component.html
@@ -2,7 +2,7 @@
   <div class="characters">
     <select id="classes" (click)="showSpells()">
       <option disabled selected hidden>Select Option</option>
-      <option *ngFor="let iclass of allClasses; let i = index" class="Name" id="class_dropdown">{{iclass}}</option>
+      <option *ngFor="let iclass of allClasses" class="Name" id="class_dropdown">{{iclass}}</option>
     </select>
   </div>
   <div class="tbl-content">

--- a/application/src/app/view-users/view-users.component.ts
+++ b/application/src/app/view-users/view-users.component.ts
@@ -129,7 +129,7 @@ export class ViewUsersComponent {
       this.http.put('http://localhost:8080/users/admin_update', JSON.stringify(Admin), options).subscribe(data => {
         
         if (200) {
-
+          alert("User " + this.curUser.Username + " updated successfully.");
           window.location.reload();
         }
       }, (error) => {


### PR DESCRIPTION
- Anywhere in the frontend that referenced the previous class numbers 1-10 have been replaced with their respective class names as strings. For example, 1 corresponds to the Sorcerer class. Anywhere in the frontend that mentioned 1 as the class, has since been changed to Sorcerer instead.